### PR TITLE
Work around performance bug

### DIFF
--- a/lopocs/database.py
+++ b/lopocs/database.py
@@ -434,17 +434,17 @@ class Session():
         conn = cls.pool.getconn()
         conn.autocommit = True
         cur = conn.cursor()
+        # work around a performance bug occuring when the Pointcloud extension is loaded
+        # before the PostGIS extension. So call postgis_version before anything to make
+        # certain that PostGIS is loaded first.
+        cur.execute('select postgis_version()')
         cur.execute(query, parameters)
         cls.pool.putconn(conn)
+        return cur
 
     @classmethod
     def query(cls, query, parameters=None):
         """Performs a single query and fetch all results
         """
-        conn = cls.pool.getconn()
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(query, parameters)
-        res = cur.fetchall()
-        cls.pool.putconn(conn)
-        return res
+        cur = cls.execute(query, parameters)
+        return cur.fetchall()

--- a/lopocs/database.py
+++ b/lopocs/database.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from multiprocessing import cpu_count
 from collections import defaultdict
+from contextlib import contextmanager
 
 import psycopg2.extras
 import psycopg2.extensions
@@ -428,23 +429,36 @@ class Session():
         return pcid, bbox_scaled
 
     @classmethod
+    @contextmanager
+    def _conn(cls):
+        conn = cls.pool.getconn()
+        conn.autocommit = True
+        yield conn
+        cls.pool.putconn(conn)
+
+    @classmethod
+    @contextmanager
+    def _execute(cls, query, parameters=None):
+        with cls._conn() as conn:
+            with conn.cursor() as cursor:
+                # work around a performance bug occuring when the Pointcloud extension
+                # is loaded before the PostGIS extension. So call postgis_version before
+                # anything to make certain that PostGIS is loaded first.
+                cursor.execute('select postgis_version()')
+                cursor.execute(query, parameters)
+                yield cursor
+
+    @classmethod
     def execute(cls, query, parameters=None):
         """Execute a pg statement without fetching results (use for DDL statement)
         """
-        conn = cls.pool.getconn()
-        conn.autocommit = True
-        cur = conn.cursor()
-        # work around a performance bug occuring when the Pointcloud extension is loaded
-        # before the PostGIS extension. So call postgis_version before anything to make
-        # certain that PostGIS is loaded first.
-        cur.execute('select postgis_version()')
-        cur.execute(query, parameters)
-        cls.pool.putconn(conn)
-        return cur
+        with cls._execute(query, parameters):
+            pass
 
     @classmethod
     def query(cls, query, parameters=None):
         """Performs a single query and fetch all results
         """
-        cur = cls.execute(query, parameters)
-        return cur.fetchall()
+        with cls._execute(query, parameters) as cursor:
+            res = cursor.fetchall()
+        return res


### PR DESCRIPTION
This works around a performance bug occuring when the PostGIS extension is loaded after the Pointcloud extension. The work-around involves making sure we firt call a PostGIS function on a connection. We will hopefully find the root-cause of this performance issue and fix it properly.

See https://www.postgresql.org/message-id/flat/49f41956-f50b-9551-1943-6e12ed12fa29%40oslandia.com#49f41956-f50b-9551-1943-6e12ed12fa29@oslandia.com for a discussion on pgsql-discuss about this.