### PR TITLE
database: fix the version reading

### DIFF
--- a/lopocs/database.py
+++ b/lopocs/database.py
@@ -2,6 +2,7 @@
 from multiprocessing import cpu_count
 from collections import defaultdict
 from contextlib import contextmanager
+from packaging import version
 
 import psycopg2.extras
 import psycopg2.extensions
@@ -315,8 +316,8 @@ class Session():
         stream patches in various formats
         '''
         # to_regclass function changed its signature in postgresql >= 9.6
-        version = cls.query('show server_version')[0][0]
-        if version < '9.6.0':
+        server_version = cls.query('show server_version')[0][0].split()[0]
+        if version.parse(server_version) < version.parse('9.6.0'):
             cls.execute("""
                 create or replace function to_regclass(text) returns regclass
                 language sql as 'select to_regclass($1::cstring)'

--- a/lopocs/database.py
+++ b/lopocs/database.py
@@ -314,9 +314,15 @@ class Session():
         '''
         Create some meta tables that stores informations used by lopocs to
         stream patches in various formats
+
+        This function uses "packaging.version.parse" to evaluate the current
+        postgres version; depending on the system, it may returns verbose
+        answers like "X.X.X (Ubuntu X.X-Xubuntu0.18.04.1)". One has to split
+        this to keep only the simple version format.
         '''
         # to_regclass function changed its signature in postgresql >= 9.6
-        server_version = cls.query('show server_version')[0][0].split()[0]
+        full_server_version = cls.query('show server_version')[0][0]
+        server_version = server_version_full.split()[0]  # Keep only "X.X.X"
         if version.parse(server_version) < version.parse('9.6.0'):
             cls.execute("""
                 create or replace function to_regclass(text) returns regclass

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ requirements = (
     'requests==2.13.0',
     'lazperf==1.2.1',
     'numpy==1.14.3',
-    'pyproj==1.9.5.1'
+    'pyproj==1.9.5.1',
+    'packaging==19.2'
 )
 
 dev_requirements = (


### PR DESCRIPTION
This PR fixes the way one reads the postgresql server version, in `lopocs/database.py` module.

This is critical as the `version < '9.6.0'` won't give the expected answer for PG>9 (the `to_regclass` function behavior is modified for versions older than 9.6.0, a side effect of the current code being that one modifies it for PG>9); hence producing a bug.

In order to fix this bug, one uses `version.parse` function from the `packaging` lib. In this way, we compare `packaging.version.Version` objects by respecting up-to-date PEP recommandations (see https://stackoverflow.com/questions/11887762/how-do-i-compare-version-numbers-in-python/11887885#11887885 for further details about this topic).

*Note:* Do not forget to split the version provided by the `psql` command `show server_version`, because it produces `packaging.version.LegacyVersion` for some OS (see https://github.com/MagicStack/asyncpg/blob/master/asyncpg/serverversion.py#L18).